### PR TITLE
chore: add text editors folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
+# Text editors config folders #
+###############################
+.idea/
+.vscode/
+
 # dependencies
 /node_modules
 


### PR DESCRIPTION
This PR adds text editors settings folders to the .gitignore file.

Alternatively, this can be solved using a global .gitignore :wink: